### PR TITLE
Minor PHP < 5.5 bug

### DIFF
--- a/app/code/community/Technooze/Timage/Helper/Data.php
+++ b/app/code/community/Technooze/Timage/Helper/Data.php
@@ -431,7 +431,7 @@ class Technooze_Timage_Helper_Data extends Mage_Core_Helper_Abstract
             Mage::helper('core/file_storage_database')->saveFileToFilesystem($this->img);
         }
 
-        if ((!file_exists($this->img) || !is_file($this->img)) && !empty($this->getPlaceholderFile())) {
+        if ((!file_exists($this->img) || !is_file($this->img)) && $this->getPlaceholderFile()) {
             $this->img = $this->getPlaceholderFile();
         }
     }


### PR DESCRIPTION
PHP < 5.5 error "Can't use method return value in write context in..." caused by passing value by reference within empty() - see http://stackoverflow.com/a/4328049/476
